### PR TITLE
Fix compilation errors

### DIFF
--- a/src/main/java/dev/openhands/currencymod/block/CurrencyGeneratorBlock.java
+++ b/src/main/java/dev/openhands/currencymod/block/CurrencyGeneratorBlock.java
@@ -1,5 +1,6 @@
 package dev.openhands.currencymod.block;
 
+import dev.openhands.currencymod.CurrencyMod;
 import net.fabricmc.fabric.api.object.builder.v1.block.FabricBlockSettings;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockRenderType;
@@ -63,5 +64,10 @@ public class CurrencyGeneratorBlock extends BlockWithEntity {
     public <T extends BlockEntity> BlockEntityTicker<T> getTicker(World world, BlockState state, BlockEntityType<T> type) {
         return validateTicker(type, CurrencyMod.CURRENCY_GENERATOR_ENTITY,
             (world1, pos, state1, be) -> CurrencyGeneratorBlockEntity.tick(world1, pos, state1, be));
+    }
+
+    @Override
+    public BlockEntityType<? extends BlockEntity> getCodec() {
+        return CurrencyMod.CURRENCY_GENERATOR_ENTITY;
     }
 }

--- a/src/main/java/dev/openhands/currencymod/data/PlayerCurrencyData.java
+++ b/src/main/java/dev/openhands/currencymod/data/PlayerCurrencyData.java
@@ -1,6 +1,7 @@
 package dev.openhands.currencymod.data;
 
 import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.world.PersistentState.Type;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.world.PersistentState;
@@ -105,8 +106,7 @@ public class PlayerCurrencyData extends PersistentState {
     public static PlayerCurrencyData getServerState(World world) {
         return world.getServer().getOverworld().getPersistentStateManager()
             .getOrCreate(
-                PlayerCurrencyData::createFromNbt,
-                PlayerCurrencyData::new,
+                Type.create(PlayerCurrencyData::createFromNbt, PlayerCurrencyData::new),
                 "currency_data"
             );
     }


### PR DESCRIPTION
This PR fixes the following compilation errors:

- Add missing getCodec() method to CurrencyGeneratorBlock
- Fix getOrCreate method call in PlayerCurrencyData
- Add missing CurrencyMod import